### PR TITLE
Removed sync/preamble from transmission

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Written and works on Windows, runs well on Linux via mono.
 
 Things you can do
 ---
-RF replay attack - attack fixed-code communication devices such as some gates, doorbells and wireless switches. I'll be publishing a guide shortly.
+RF replay attack - attack fixed-code communication devices such as some gates, doorbells and wireless switches. ~~I'll be publishing a guide shortly~~ (shortly: 3 years). A guide is now available [here](https://github.com/jglim/CCManager/files/612566/CCManager.pdf).
 
 
 ![CCManager software](https://raw.github.com/jglim/CCManager/master/other/images/doorbell.gif)
@@ -87,7 +87,7 @@ Limitations
 ---
 Restricted to 61 bytes of data per transmission. The USB-SPI bridge appears to be incapable of communicating fast enough, and also I do not know if it is possible to disable the entire RX FIFO so that the TX FIFO can be doubled.
 
-I haven't figured a way to disable the CC1101's preamble and sync transmission. However most transmissions still work fine since only the first portion (may) be discarded.
+~~I haven't figured a way to disable the CC1101's preamble and sync transmission. However most transmissions still work fine since only the first portion (may) be discarded.~~ This has been fixed. Thanks [@AzInstall](https://github.com/AzInstall) !
 
 Other Notes
 ---

--- a/software/CCManager/CCManager/CCRegister.cs
+++ b/software/CCManager/CCManager/CCRegister.cs
@@ -109,7 +109,7 @@ namespace CCManager
 			{"FIFOTHR", 0x47},
 			{"PKTCTRL0", 0x01},
 			{"FSCTRL1", 0x06},
-			{"MDMCFG2", 0x33},
+			{"MDMCFG2", 0x30},
 			{"MDMCFG1", 0x02},
 			{"DEVIATN", 0x15},
 			{"MCSM1", 0x00},


### PR DESCRIPTION
Signals should now be sent as-is, without sync/preamble. MDMCFG2
register changed from 0x33 -> 0x30 (
https://github.com/jglim/CCManager/issues/2 )

Also linked to replay guide.